### PR TITLE
Update gocryptfs binary to version v2.5.3-3-g27abe23

### DIFF
--- a/.github/workflows/check-arm64-binary-unittesting.yml
+++ b/.github/workflows/check-arm64-binary-unittesting.yml
@@ -6,57 +6,38 @@ jobs:
   test:
     runs-on: buildjet-2vcpu-ubuntu-2204-arm64
     steps:
-    - uses: actions/checkout@v4
-    
+    - name: Checkout your magisk repository
+      uses: actions/checkout@v4
+      
+    - name: Checkout gocryptfs source repository
+      uses: actions/checkout@v4
+      with:
+        repository: rfjakob/gocryptfs
+        path: gocryptfs-source
+        
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: '1.20'
-    
-    - name: Get latest release info
-      id: latest_release
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const response = await github.rest.repos.listReleases({
-            owner: context.repo.owner,
-            repo: context.repo.repo
-          });
-          
-          const releases = response.data.filter(release => 
-            release.tag_name.startsWith('arm64-v')
-          );
-          
-          if (releases.length === 0) {
-            core.setFailed('No ARM64 releases found');
-            return;
-          }
-          
-          const latest = releases.sort((a, b) => 
-            new Date(b.created_at) - new Date(a.created_at)
-          )[0];
-          
-          core.setOutput('tag', latest.tag_name);
-          core.setOutput('url', latest.assets[0].browser_download_url);
-    
-    - name: Download gocryptfs binary
+        
+    - name: Install dependencies
       run: |
-        mkdir -p system/bin
-        curl -L ${{ steps.latest_release.outputs.url }} -o system/bin/gocryptfs
-        chmod +x system/bin/gocryptfs
-    
-    - name: Verify binary
+        sudo apt-get update
+        sudo apt-get install -y build-essential libssl-dev libfuse-dev pkg-config fuse
+        
+    - name: Copy binary to source repository
       run: |
-        ls -la system/bin
-        file system/bin/gocryptfs
-    
-    - name: Run tests
+        ls -la system/bin/
+        mkdir -p gocryptfs-source/build
+        cp system/bin/gocryptfs gocryptfs-source/build/
+        chmod +x gocryptfs-source/build/gocryptfs
+        
+    - name: Prepare test environment in source repo
+      working-directory: gocryptfs-source
+      run: go mod tidy
+        
+    - name: Run Go tests with custom binary
+      working-directory: gocryptfs-source
       run: |
-        if [ -f "system/bin/gocryptfs" ]; then
-          go test -v ./... -exec ./system/bin/gocryptfs
-        else
-          echo "gocryptfs binary not found!"
-          exit 1
-        fi
-      shell: bash
+        # The actual test command may need to be adjusted based on the gocryptfs test structure
+        GOFLAGS="-exec $(pwd)/build/gocryptfs" go test -v ./...

--- a/.github/workflows/check-arm64-binary-unittesting.yml
+++ b/.github/workflows/check-arm64-binary-unittesting.yml
@@ -8,45 +8,35 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Download gocryptfs binary
+    - name: Install dependencies
       run: |
-        mkdir -p system/bin
-        curl -L ${{ steps.latest_release.outputs.url || github.event.repository.html_url }}/releases/latest/download/gocryptfs -o system/bin/gocryptfs
-        chmod +x system/bin/gocryptfs
+        sudo apt-get update
+        sudo apt-get install -y fuse
     
-    - name: Verify binary
+    - name: Test binary
       run: |
-        ls -la system/bin
+        # Print file info
         file system/bin/gocryptfs
-    
-    - name: Test gocryptfs basic functionality
-      run: |
-        if [ -f "system/bin/gocryptfs" ]; then
-          # Create test directories
-          mkdir -p test/cipher test/plain
+        
+        # Test if binary is properly executable
+        if [ -x "system/bin/gocryptfs" ]; then
+          # Try to run version check
+          ./system/bin/gocryptfs -version || echo "Failed to run version check"
           
-          # Test version output
-          ./system/bin/gocryptfs -version
-          
-          # Initialize a test filesystem
-          ./system/bin/gocryptfs -init -quiet test/cipher
-          
-          # Mount the filesystem
-          ./system/bin/gocryptfs test/cipher test/plain
-          
-          # Create a test file
-          echo "Test content" > test/plain/testfile.txt
-          
-          # Verify the file exists and is encrypted in the cipher directory
-          ls -la test/plain
-          ls -la test/cipher
-          
-          # Unmount
-          fusermount -u test/plain
-          
-          echo "Basic functionality test passed!"
+          # If the file appears to be text, print its content
+          if file system/bin/gocryptfs | grep -q text; then
+            echo "File appears to be text, printing content:"
+            cat system/bin/gocryptfs
+          fi
         else
-          echo "gocryptfs binary not found!"
-          exit 1
+          echo "Binary is not executable"
+          
+          # Try to make it executable and check again
+          chmod +x system/bin/gocryptfs
+          if ./system/bin/gocryptfs -version; then
+            echo "Binary works after chmod"
+          else
+            echo "Binary still fails after chmod"
+          fi
         fi
       shell: bash

--- a/.github/workflows/check-arm64-binary-unittesting.yml
+++ b/.github/workflows/check-arm64-binary-unittesting.yml
@@ -6,38 +6,47 @@ jobs:
   test:
     runs-on: buildjet-2vcpu-ubuntu-2204-arm64
     steps:
-    - name: Checkout your magisk repository
-      uses: actions/checkout@v4
-      
-    - name: Checkout gocryptfs source repository
-      uses: actions/checkout@v4
-      with:
-        repository: rfjakob/gocryptfs
-        path: gocryptfs-source
-        
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.20'
-        
-    - name: Install dependencies
+    - uses: actions/checkout@v4
+    
+    - name: Download gocryptfs binary
       run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential libssl-dev libfuse-dev pkg-config fuse
-        
-    - name: Copy binary to source repository
+        mkdir -p system/bin
+        curl -L ${{ steps.latest_release.outputs.url || github.event.repository.html_url }}/releases/latest/download/gocryptfs -o system/bin/gocryptfs
+        chmod +x system/bin/gocryptfs
+    
+    - name: Verify binary
       run: |
-        ls -la system/bin/
-        mkdir -p gocryptfs-source/build
-        cp system/bin/gocryptfs gocryptfs-source/build/
-        chmod +x gocryptfs-source/build/gocryptfs
-        
-    - name: Prepare test environment in source repo
-      working-directory: gocryptfs-source
-      run: go mod tidy
-        
-    - name: Run Go tests with custom binary
-      working-directory: gocryptfs-source
+        ls -la system/bin
+        file system/bin/gocryptfs
+    
+    - name: Test gocryptfs basic functionality
       run: |
-        # The actual test command may need to be adjusted based on the gocryptfs test structure
-        GOFLAGS="-exec $(pwd)/build/gocryptfs" go test -v ./...
+        if [ -f "system/bin/gocryptfs" ]; then
+          # Create test directories
+          mkdir -p test/cipher test/plain
+          
+          # Test version output
+          ./system/bin/gocryptfs -version
+          
+          # Initialize a test filesystem
+          ./system/bin/gocryptfs -init -quiet test/cipher
+          
+          # Mount the filesystem
+          ./system/bin/gocryptfs test/cipher test/plain
+          
+          # Create a test file
+          echo "Test content" > test/plain/testfile.txt
+          
+          # Verify the file exists and is encrypted in the cipher directory
+          ls -la test/plain
+          ls -la test/cipher
+          
+          # Unmount
+          fusermount -u test/plain
+          
+          echo "Basic functionality test passed!"
+        else
+          echo "gocryptfs binary not found!"
+          exit 1
+        fi
+      shell: bash

--- a/.github/workflows/check-arm64-binary-unittesting.yml
+++ b/.github/workflows/check-arm64-binary-unittesting.yml
@@ -1,20 +1,62 @@
 name: gocryptfs arm64 Unit Testing
-
 on:
   pull_request:
     branches: [ main ]
-
 jobs:
   test:
     runs-on: buildjet-2vcpu-ubuntu-2204-arm64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.20'
+    
+    - name: Get latest release info
+      id: latest_release
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const response = await github.rest.repos.listReleases({
+            owner: context.repo.owner,
+            repo: context.repo.repo
+          });
+          
+          const releases = response.data.filter(release => 
+            release.tag_name.startsWith('arm64-v')
+          );
+          
+          if (releases.length === 0) {
+            core.setFailed('No ARM64 releases found');
+            return;
+          }
+          
+          const latest = releases.sort((a, b) => 
+            new Date(b.created_at) - new Date(a.created_at)
+          )[0];
+          
+          core.setOutput('tag', latest.tag_name);
+          core.setOutput('url', latest.assets[0].browser_download_url);
+    
+    - name: Download gocryptfs binary
+      run: |
+        mkdir -p system/bin
+        curl -L ${{ steps.latest_release.outputs.url }} -o system/bin/gocryptfs
+        chmod +x system/bin/gocryptfs
+    
+    - name: Verify binary
+      run: |
+        ls -la system/bin
+        file system/bin/gocryptfs
+    
     - name: Run tests
       run: |
-        chmod +x system/bin/gocryptfs
-        go test -v ./... -exec ./system/bin/gocryptfs
+        if [ -f "system/bin/gocryptfs" ]; then
+          go test -v ./... -exec ./system/bin/gocryptfs
+        else
+          echo "gocryptfs binary not found!"
+          exit 1
+        fi
       shell: bash


### PR DESCRIPTION
Automated update of gocryptfs binary to version v2.5.3-3-g27abe23.
This pull request updates the gocryptfs binary in the Magisk module to the latest build version.